### PR TITLE
Enable star models based on staging vars

### DIFF
--- a/models/extractor_reports/intermediate/int_sap__0employee_date_changes.sql
+++ b/models/extractor_reports/intermediate/int_sap__0employee_date_changes.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=(var('sap_using_pa0000', True) and var('sap_using_pa0001', True) and var('sap_using_pa0007', True) and var('sap_using_pa0008', True) and var('sap_using_pa0031', True))) }}
+
 {% set employee_models = ['pa0000', 'pa0001', 'pa0007', 'pa0008', 'pa0031'] %}
 
 with

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__company.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__company.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=var('sap_using_t001w', True)) }}
+
 select
     mandt as client_id,
     bukrs as company_code_id,

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__customer.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__customer.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=var('sap_using_kna1', True)) }}
+
 select
     kunnr as customer_id,
     mandt as client_id,

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__material.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__material.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=(var('sap_using_mara', True) and var('sap_using_makt', True))) }}
+
 with mara as (
     select *
     from {{ ref('stg_sap__mara') }}

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__material_type.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__material_type.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=(var('sap_using_t134', True) and var('sap_using_t134t', True))) }}
+
 with t134 as (
     select *
     from {{ ref('stg_sap__t134') }}

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__plant.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__plant.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=var('sap_using_t001w', True)) }}
+
 select
     mandt as client_id,
     werks as plant_id,

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_document_category.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_document_category.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=(var('sap_using_dd07l', True) and var('sap_using_dd07t', True))) }}
+
 with dd07l as (
     select *
     from {{ ref('stg_sap__dd07l') }}

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_document_header.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_document_header.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=var('sap_using_ekko', True)) }}
+
 select
     mandt as client_id,
     ebeln as purchasing_document_id,

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_document_history.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_document_history.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=var('sap_using_ekbe', True)) }}
+
 select
     mandt as client_id,
     ebeln as purchasing_document_id,

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_document_item.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_document_item.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=var('sap_using_ekpo', True)) }}
+
 select
     mandt as client_id,
     ebeln as purchasing_document_id,

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_document_overview.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_document_overview.sql
@@ -1,4 +1,6 @@
-select 
+{{ config(enabled=var('sap_using_ekbe', True)) }}
+
+select
     purchasing_document_id,
     purchasing_document_item_id,
     max(delivery_completed) delivery_completed,

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_document_schedule_line.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_document_schedule_line.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=var('sap_using_eket', True)) }}
+
 select
     mandt as client_id,
     ebeln as purchasing_document_id,

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_document_schedule_total.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_document_schedule_total.sql
@@ -1,4 +1,6 @@
-select 
+{{ config(enabled=var('sap_using_eket', True)) }}
+
+select
     purchasing_document_id, 
     purchasing_document_item_id, 
     max(item_delivery_date) as lastest_scheduled_delivery_date,

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_document_status.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_document_status.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=(var('sap_using_dd07l', True) and var('sap_using_dd07t', True))) }}
+
 with dd07l as (
     select *
     from {{ ref('stg_sap__dd07l') }}

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_document_type.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_document_type.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=(var('sap_using_t161', True) and var('sap_using_t161t', True))) }}
+
 with t161 as (
     select *
     from {{ ref('stg_sap__t161') }}

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_group.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__purchasing_group.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=var('sap_using_t024', True)) }}
+
 select
     ekgrp as purchasing_group_id,
     mandt as client_id,

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__sales_document_header.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__sales_document_header.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=var('sap_using_vbak', True)) }}
+
 select
 	mandt as client_id,
     vbeln as sales_document_id,

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__sales_document_header_status.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__sales_document_header_status.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=var('sap_using_vbuk', True)) }}
+
 select
     mandt as client_id,
     vbeln as sales_document_id,

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__sales_document_item.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__sales_document_item.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=var('sap_using_vbap', True)) }}
+
 select
     mandt as client_id,
     posnr as sales_document_item_id,

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__sales_document_item_status.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__sales_document_item_status.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=var('sap_using_vbup', True)) }}
+
 select
     mandt as client_id,
     posnr as sd_item_id,

--- a/models/sales_and_procurement/star_schema/intermediate/int_sap__sales_document_rejection_reason.sql
+++ b/models/sales_and_procurement/star_schema/intermediate/int_sap__sales_document_rejection_reason.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=(var('sap_using_tvag', True) and var('sap_using_tvagt', True))) }}
+
 with tvag as (
     select *
     from {{ ref('stg_sap__tvag') }}

--- a/models/sales_and_procurement/star_schema/sap__dim_customer.sql
+++ b/models/sales_and_procurement/star_schema/sap__dim_customer.sql
@@ -1,4 +1,6 @@
-select	
+{{ config(enabled=var('sap_using_kna1', True)) }}
+
+select
 	ltrim(customer_id, '0' ) as customer_number,
 	country_key_id,
 	name as customer_name,

--- a/models/sales_and_procurement/star_schema/sap__dim_material.sql
+++ b/models/sales_and_procurement/star_schema/sap__dim_material.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=(var('sap_using_mara', True) and var('sap_using_makt', True) and var('sap_using_t134', True) and var('sap_using_t134t', True))) }}
+
 with material as (
     select *
     from {{ ref('int_sap__material') }}

--- a/models/sales_and_procurement/star_schema/sap__dim_plant.sql
+++ b/models/sales_and_procurement/star_schema/sap__dim_plant.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=var('sap_using_t001w', True)) }}
+
 select
     mandt as client_id,
     werks as plant_id,

--- a/models/sales_and_procurement/star_schema/sap__dim_purchasing_order.sql
+++ b/models/sales_and_procurement/star_schema/sap__dim_purchasing_order.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=(var('sap_using_ekko', True) and var('sap_using_dd07l', True) and var('sap_using_dd07t', True) and var('sap_using_t161', True) and var('sap_using_t161t', True) and var('sap_using_t024', True))) }}
+
 with purchasing_document_header as (
     select *
     from {{ ref('int_sap__purchasing_document_header') }}

--- a/models/sales_and_procurement/star_schema/sap__dim_purchasing_organization.sql
+++ b/models/sales_and_procurement/star_schema/sap__dim_purchasing_organization.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=(var('sap_using_ekko', True) and var('sap_using_dd07l', True) and var('sap_using_dd07t', True) and var('sap_using_t161', True) and var('sap_using_t161t', True) and var('sap_using_t024', True))) }}
+
 with purchasing_document_header as (
     select *
     from {{ ref('int_sap__purchasing_document_header') }}

--- a/models/sales_and_procurement/star_schema/sap__dim_rejection_reason.sql
+++ b/models/sales_and_procurement/star_schema/sap__dim_rejection_reason.sql
@@ -1,4 +1,6 @@
-select 
+{{ config(enabled=(var('sap_using_tvag', True) and var('sap_using_tvagt', True))) }}
+
+select
 	reason_rejection_id, 
 	description  as rejection_reason_description
 from {{ ref('int_sap__sales_document_rejection_reason') }}

--- a/models/sales_and_procurement/star_schema/sap__fact_purchasing_order.sql
+++ b/models/sales_and_procurement/star_schema/sap__fact_purchasing_order.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=(var('sap_using_ekpo', True) and var('sap_using_ekko', True) and var('sap_using_t001w', True) and var('sap_using_ekbe', True) and var('sap_using_eket', True))) }}
+
 with purchasing_document_item as (
     select *
     from {{ ref('int_sap__purchasing_document_item') }}

--- a/models/sales_and_procurement/star_schema/sap__fact_sales_order.sql
+++ b/models/sales_and_procurement/star_schema/sap__fact_sales_order.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=(var('sap_using_vbak', True) and var('sap_using_vbap', True) and var('sap_using_vbuk', True) and var('sap_using_vbup', True))) }}
+
 with sales_document_header as (
     select *
     from {{ ref('int_sap__sales_document_header') }}


### PR DESCRIPTION
## Summary
- add `enabled` configs to intermediate models in the star schema
- gate star schema models on the staging variables their inputs require
- ensure extractor intermediate `int_sap__0employee_date_changes` is also gated

## Testing
- `dbt --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866b7ecf9948323a041fbb709ef5e0b